### PR TITLE
Move res wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea/
+move_researchdata/tools/__pycache__/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "CGG"]
+	path = CGG
+	url = git@github.com:ClinicalGenomicsGBG/CGG.git

--- a/move_researchdata/.gitignore
+++ b/move_researchdata/.gitignore
@@ -1,1 +1,2 @@
 demuxdir_runlist.txt
+__pycache__/

--- a/move_researchdata/.gitignore
+++ b/move_researchdata/.gitignore
@@ -1,0 +1,1 @@
+demuxdir_runlist.txt

--- a/move_researchdata/README.md
+++ b/move_researchdata/README.md
@@ -9,10 +9,21 @@ to have root permissions set.
 The script uses the python libraries sample-sheet and click, and needs an environment with
 these two. A simple environment with only these exists called 'move_research'.
 
-### Usage
+### Usage, stand-alone
 ```
 $ sudo su
 $ module load miniconda/4.8.3
 $ source activate move_research
-$ python3 move_researchdata/move_researchdata.py -d /path/to/demultiplexdir/
+$ python3 move_researchdata/move_researchdata.py -d /path/to/demultiplexdir/of/run
+```
+
+There is also a wrapper script for finding new demultiplex dirs of sequencing runs,a nd moving any research data in it.
+This currently looks in the 2 novaseq folders as well as the nextseq folder.
+
+## Usage, wrapper
+```
+$ sudo su
+$ module load miniconda/4.8.3
+$ source activate move_research
+$ python3 move_researchdata/wrapper.py
 ```

--- a/move_researchdata/conda-env/move_research.yaml
+++ b/move_researchdata/conda-env/move_research.yaml
@@ -4,3 +4,4 @@ channels:
 dependencies:
   - sample-sheet
   - click
+  - PyYAML

--- a/move_researchdata/configs/wrapper_config.yaml
+++ b/move_researchdata/configs/wrapper_config.yaml
@@ -1,5 +1,5 @@
 instrument_demux_paths:
-  novaseq_687: '/seqstore/instruments/novaseq_687_gc/Demultiplexdir/'
+  novaseq_687: '/seqstore/instruments/novaseq_687_gc/Demultiplexdir'
   novaseq_A01736: '/seqstore/instruments/novaseq_A01736/Demultiplexdir'
   nextseq_500175: '/seqstore/instruments/nextseq_500175_gc/Demultiplexdir'
 

--- a/move_researchdata/configs/wrapper_config.yaml
+++ b/move_researchdata/configs/wrapper_config.yaml
@@ -3,5 +3,5 @@ instrument_demux_paths:
   novaseq_A01736: '/seqstore/instruments/novaseq_A01736/Demultiplexdir'
   nextseq_500175: '/seqstore/instruments/nextseq_500175_gc/Demultiplexdir'
 
-logfile: '/medstore/logs/cronlogs/move_researchdata'
+logpath: '/medstore/logs/cronlogs/move_researchdata'
 previous_runs_file_path: 'demuxdir_runlist.txt'

--- a/move_researchdata/configs/wrapper_config.yaml
+++ b/move_researchdata/configs/wrapper_config.yaml
@@ -5,3 +5,5 @@ instrument_demux_paths:
 
 logpath: '/medstore/logs/cronlogs/move_researchdata'
 previous_runs_file_path: 'demuxdir_runlist.txt'
+
+outfolder: '/seqstore/remote/outbox/research_projects'

--- a/move_researchdata/configs/wrapper_config.yaml
+++ b/move_researchdata/configs/wrapper_config.yaml
@@ -1,0 +1,7 @@
+instrument_demux_paths:
+  novaseq_687: '/seqstore/instruments/novaseq_687_gc/Demultiplexdir/'
+  novaseq_A01736: '/seqstore/instruments/novaseq_A01736/Demultiplexdir'
+  nextseq_500175: '/seqstore/instruments/nextseq_500175_gc/Demultiplexdir'
+
+logfile: '/medstore/logs/cronlogs/move_researchdata'
+previous_runs_file_path: 'demuxdir_runlist.txt'

--- a/move_researchdata/configs/wrapper_config.yaml
+++ b/move_researchdata/configs/wrapper_config.yaml
@@ -7,3 +7,8 @@ logpath: '/medstore/logs/cronlogs/move_researchdata'
 previous_runs_file_path: 'demuxdir_runlist.txt'
 
 outfolder: '/seqstore/remote/outbox/research_projects'
+
+email:
+  recipient: 'anders.lind.cgg@gu.se'
+  sender: 'cgg-it@gu.se'
+  subject: 'ERROR: Move Research Wrapper'

--- a/move_researchdata/configs/wrapper_config.yaml
+++ b/move_researchdata/configs/wrapper_config.yaml
@@ -9,6 +9,6 @@ previous_runs_file_path: 'demuxdir_runlist.txt'
 outfolder: '/seqstore/remote/outbox/research_projects'
 
 email:
-  recipient: 'anders.lind.cgg@gu.se'
+  recipient: 'cgg-logs@gu.se'
   sender: 'cgg-it@gu.se'
   subject: 'ERROR: Move Research Wrapper'

--- a/move_researchdata/move_researchdata.py
+++ b/move_researchdata/move_researchdata.py
@@ -17,6 +17,9 @@ from tools.helpers import setup_logger
 @click.option('-o', '--outbox', default='/seqstore/remote/outbox/research_projects',
               help='Path to outbox', show_default=True)
 def main(demultiplexdir, outbox):
+    move_data(demultiplexdir, outbox)
+
+def move_data(demultiplexdir, outbox):
     # Set up the logfile and start logging
     logger = setup_logger('mv_resproj')
     logger.info(f'Looking for data belonging to research projects in {demultiplexdir}.')
@@ -24,20 +27,20 @@ def main(demultiplexdir, outbox):
     # Check that the demultiplexdir exists
     if not os.path.exists(demultiplexdir):
         logger.error(f"The path {demultiplexdir} does not seem to exist.")
-        sys.exit()
+        sys.exit(1)
 
     # Look for path to SampleSheet
     samplesheet_path = os.path.join(demultiplexdir, 'SampleSheet.csv')
     if not os.path.exists(samplesheet_path):
         logger.error(f'Could not SampleSheet.csv @ {demultiplexdir}')
-        sys.exit()
+        sys.exit(1)
 
     # Check that user has write permissions in outbox
     if os.access(outbox, os.W_OK):
         logger.info(f"User has write permissions in {outbox}. Proceeding.")
     else:
         logger.error(f"No write permissions in {outbox}. Exiting.")
-        sys.exit()
+        sys.exit(1)
 
 
     # Parse samplesheet and look for data belonging to research projects
@@ -70,7 +73,7 @@ def main(demultiplexdir, outbox):
         #Check that there is an outbox for the project
         if not os.path.exists(project_outbox):
             logger.error(f"Could not find outbox folder for {project}. Please create it. Exiting.")
-            sys.exit()
+            sys.exit(1)
 
         # Make fastq folder if not existing
         fastq_outbox = os.path.join(project_outbox, run_name, 'fastq')

--- a/move_researchdata/move_researchdata.py
+++ b/move_researchdata/move_researchdata.py
@@ -59,7 +59,7 @@ def move_data(demultiplexdir, outbox, logger):
         logger.info(f"Found {num_samples} samples belonging to {len(projects)} research projects.")
     else:
         logger.info(f"Could not find any research samples in {demultiplexdir}. Exiting.")
-        sys.exit()
+        return
 
     # Check that there is an outbox folder for all projects
     for project, samples in projects.items():

--- a/move_researchdata/move_researchdata.py
+++ b/move_researchdata/move_researchdata.py
@@ -27,11 +27,11 @@ def main(demultiplexdir, outbox, include_fastqc):
 
     logger.info(f"Completed {num_transfers} transfers.")
 
-def move_data(demultiplexdir, outbox, logger, include_fastqc):
+def move_data(demultiplexdir, outbox, logger, include_fastqc = False):
     # Look for path to SampleSheet
     samplesheet_path = os.path.join(demultiplexdir, 'SampleSheet.csv')
     if not os.path.exists(samplesheet_path):
-        logger.error(f'Could not SampleSheet.csv @ {demultiplexdir}')
+        logger.warning(f'No SampleSheet.csv @ {demultiplexdir}. Skipping run.')
         raise FileNotFoundError(f"No SampleSheet.csv @ {demultiplexdir}")
 
     # Check that user has write permissions in outbox

--- a/move_researchdata/move_researchdata.py
+++ b/move_researchdata/move_researchdata.py
@@ -92,6 +92,7 @@ def move_data(demultiplexdir, outbox, logger):
             rsync_results = subprocess.run(rsync_cmd)
             if rsync_results.returncode != 0:
                 logger.error(f"Problems copying fastq files for sample {sample} via rsync.")
+                raise ConnectionError
 
             # If there are fastqc results, move them as well
             fastqc_files = glob.glob(os.path.join(demultiplexdir, 'fastqc/') + sample + "*_fastqc.zip")

--- a/move_researchdata/move_researchdata.py
+++ b/move_researchdata/move_researchdata.py
@@ -109,10 +109,10 @@ def move_data(demultiplexdir, outbox, logger):
                 rsync_results = subprocess.run(rsync_cmd)
                 if rsync_results.returncode != 0:
                     logger.error(f"Problems copying fastQC files for sample {sample} via rsync.")
-                else:
-                    successful_transfers += 1
 
-            return successful_transfers
+            successful_transfers += 1
+
+    return successful_transfers
 
 
 if __name__ == '__main__':

--- a/move_researchdata/move_researchdata.py
+++ b/move_researchdata/move_researchdata.py
@@ -9,7 +9,7 @@ from collections import defaultdict
 
 import click
 from sample_sheet import SampleSheet
-from tools.helpers import setuo_logger
+from tools.helpers import setup_logger
 
 @click.command()
 @click.option('-d', '--demultiplexdir', required=True,

--- a/move_researchdata/move_researchdata.py
+++ b/move_researchdata/move_researchdata.py
@@ -109,7 +109,7 @@ def move_data(demultiplexdir, outbox, logger):
                 # Transfer via rsync
                 rsync_results = subprocess.run(rsync_cmd)
                 if rsync_results.returncode != 0:
-                    logger.error(f"Problems copying fastQC files for sample {sample} via rsync.")
+                    logger.warning(f"Problems copying fastQC files for sample {sample} via rsync.")
 
             successful_transfers += 1
 

--- a/move_researchdata/move_researchdata.py
+++ b/move_researchdata/move_researchdata.py
@@ -102,8 +102,7 @@ def move_data(demultiplexdir, outbox, logger, include_fastqc = False):
                 if len(fastqc_files) > 0:
                     #Make fast-QC folder if not existing
                     fastqc_outbox = os.path.join(project_outbox, run_name, 'fastqc')
-                    if not os.path.exists(fastqc_outbox):
-                        os.makedirs(fastqc_outbox)
+                    os.makedirs(fastqc_outbox, exists_ok = True)
 
                     #Transfer fastq zip file
                     # Make the rsync command

--- a/move_researchdata/move_researchdata.py
+++ b/move_researchdata/move_researchdata.py
@@ -4,12 +4,12 @@ import os
 import re
 import sys
 import glob
-import logging
 import subprocess
 from collections import defaultdict
 
 import click
 from sample_sheet import SampleSheet
+from tools.helpers import setuo_logger
 
 @click.command()
 @click.option('-d', '--demultiplexdir', required=True,
@@ -111,16 +111,7 @@ def main(demultiplexdir, outbox):
 
     logger.info(f"All transfers complete.")
 
-def setup_logger(name):
-    logger = logging.getLogger(name)
-    logger.setLevel(logging.DEBUG)
 
-    stream_handle = logging.StreamHandler()
-    stream_handle.setLevel(logging.DEBUG)
-    stream_handle.setFormatter(logging.Formatter('%(asctime)s - %(levelname)s - %(message)s'))
-    logger.addHandler(stream_handle)
-
-    return logger
 
 if __name__ == '__main__':
     main()

--- a/move_researchdata/tools/helpers.py
+++ b/move_researchdata/tools/helpers.py
@@ -1,0 +1,12 @@
+import logging
+
+def setup_logger(name):
+    logger = logging.getLogger(name)
+    logger.setLevel(logging.DEBUG)
+
+    stream_handle = logging.StreamHandler()
+    stream_handle.setLevel(logging.DEBUG)
+    stream_handle.setFormatter(logging.Formatter('%(asctime)s - %(levelname)s - %(message)s'))
+    logger.addHandler(stream_handle)
+
+    return logger

--- a/move_researchdata/tools/helpers.py
+++ b/move_researchdata/tools/helpers.py
@@ -28,9 +28,13 @@ def look_for_runs(root_path):
     return [path for path in found_paths if re.search(regex, os.path.basename(path))]
 
 def gen_email_body(error_runs, log_path):
-    body = "While trying to move research data to their correct sFTP folder, " \
-           "the following runs gave errors:\n" + "\n".join(error_runs) +\
-            f"\n\nPlease see the complete log @ {log_path}.\n\n" \
-           f"Kind regards,\nClinical Genomics IT-group."
+    body = '\n'. join(["While trying to move research data to their correct sFTP folder, "
+                       "the following runs gave errors.",
+                       "\n".join(error_runs),
+                       '',
+                       '',
+                       f"Please see the complete log @ {log_path}.",
+                       '',
+                       "Kind regards,\nClinical Genomics IT-group."])
 
     return body

--- a/move_researchdata/tools/helpers.py
+++ b/move_researchdata/tools/helpers.py
@@ -1,13 +1,19 @@
 import logging
 
-def setup_logger(name):
+def setup_logger(name, log_path=None):
     logger = logging.getLogger(name)
     logger.setLevel(logging.DEBUG)
 
     stream_handle = logging.StreamHandler()
     stream_handle.setLevel(logging.DEBUG)
-    stream_handle.setFormatter(logging.Formatter('%(asctime)s - %(levelname)s - %(message)s'))
+    stream_handle.setFormatter(logging.Formatter('%(asctime)s - %(levelname)s - %(module)s - %(message)s'))
     logger.addHandler(stream_handle)
+
+    if log_path:
+        file_handle = logging.FileHandler(log_path, 'a')
+        file_handle.setLevel(logging.DEBUG)
+        file_handle.setFormatter(logging.Formatter('%(asctime)s - %(levelname)s - %(module)s - %(message)s'))
+        logger.addHandler(file_handle)
 
     return logger
 

--- a/move_researchdata/tools/helpers.py
+++ b/move_researchdata/tools/helpers.py
@@ -10,3 +10,9 @@ def setup_logger(name):
     logger.addHandler(stream_handle)
 
     return logger
+
+def look_for_runs(root_path):
+    found_paths = glob.glob(os.path.join(root_path, '*'))
+    regex = '^[0-9]{6}_A[0-9]{5}_[0-9]{4}_.{10}$'
+    return [path for path in found_paths if re.search(regex, os.path.basename(path))]
+

--- a/move_researchdata/tools/helpers.py
+++ b/move_researchdata/tools/helpers.py
@@ -4,6 +4,7 @@ import os
 import re
 
 def setup_logger(name, log_path=None):
+    """Initialise a log file using the logging package"""
     logger = logging.getLogger(name)
     logger.setLevel(logging.DEBUG)
 
@@ -21,6 +22,7 @@ def setup_logger(name, log_path=None):
     return logger
 
 def look_for_runs(root_path):
+    """Find all regular looking run folders at a given path"""
     found_paths = glob.glob(os.path.join(root_path, '*'))
     regex = '^[0-9]{6}_(?:NB|A)[0-9]*_[0-9]{4}_.{10}$' # NovaSeq & NextSeq
     return [path for path in found_paths if re.search(regex, os.path.basename(path))]

--- a/move_researchdata/tools/helpers.py
+++ b/move_researchdata/tools/helpers.py
@@ -1,4 +1,7 @@
 import logging
+import glob
+import os
+import re
 
 def setup_logger(name, log_path=None):
     logger = logging.getLogger(name)
@@ -19,6 +22,6 @@ def setup_logger(name, log_path=None):
 
 def look_for_runs(root_path):
     found_paths = glob.glob(os.path.join(root_path, '*'))
-    regex = '^[0-9]{6}_A[0-9]{5}_[0-9]{4}_.{10}$'
+    regex = '^[0-9]{6}_(?:NB|A)[0-9]*_[0-9]{4}_.{10}$' # NovaSeq & NextSeq
     return [path for path in found_paths if re.search(regex, os.path.basename(path))]
 

--- a/move_researchdata/tools/helpers.py
+++ b/move_researchdata/tools/helpers.py
@@ -27,3 +27,10 @@ def look_for_runs(root_path):
     regex = '^[0-9]{6}_(?:NB|A)[0-9]*_[0-9]{4}_.{10}$' # NovaSeq & NextSeq
     return [path for path in found_paths if re.search(regex, os.path.basename(path))]
 
+def gen_email_body(error_runs, log_path):
+    body = "While trying to move research data to their correct sFTP folder, " \
+           "the following runs gave errors:\n" + "\n".join(error_runs) +\
+            f"\n\nPlease see the complete log @ {log_path}.\n\n" \
+           f"Kind regards,\nClinical Genomics IT-group."
+
+    return body

--- a/move_researchdata/wrapper.py
+++ b/move_researchdata/wrapper.py
@@ -31,9 +31,7 @@ def wrapper(config_path):
 
     ## Find all non processed demultiplex dirs
     runs_to_process = []
-    for instrument in config['instrument_demux_paths'].keys():
-        demux_path = config['instrument_demux_paths'][instrument]
-        ## Get all demultiplexed runs
+    for instrument, demux_path in config['instrument_demux_paths'].items():
         runs = look_for_runs(demux_path)
         for run in runs:
             if os.path.basename(run) in previous_runs:

--- a/move_researchdata/wrapper.py
+++ b/move_researchdata/wrapper.py
@@ -18,6 +18,9 @@ def wrapper(config_path):
     logger = setup_logger('wrapper', os.path.join(log_path, 'wopr_wrapper.log'))
 
     ## Read in demuxdir-runlist.txt
+    runlist = config['previous_runs_file_path']
+    with open(runlist, 'r') as prev:
+        previous_runs = [line.rstrip() for line in prev]
 
     ## Find all non processed demultiplex dirs
 

--- a/move_researchdata/wrapper.py
+++ b/move_researchdata/wrapper.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python
+
+import click
+
+def look_for_runs(root_path):
+    found_paths = glob.glob(os.path.join(root_path, '*'))
+    regex = '^[0-9]{6}_A[0-9]{5}_[0-9]{4}_.{10}$'
+    return [path for path in found_paths if re.search(regex, os.path.basename(path))]

--- a/move_researchdata/wrapper.py
+++ b/move_researchdata/wrapper.py
@@ -3,8 +3,11 @@
 import os
 import click
 import yaml
-from tools.helpers import setup_logger, look_for_runs
+from tools.helpers import setup_logger, look_for_runs, gen_email_body
 from move_researchdata import move_data
+import sys
+sys.path.append("..") # Adds higher directory to python modules path.
+from CGG.tools.emailer import send_email
 
 @click.command()
 @click.option('--config-path', default='configs/wrapper_config.yaml',
@@ -21,7 +24,8 @@ def wrapper(config_path):
 
     ## Initialise logging
     log_path = config['logpath']
-    logger = setup_logger('wrapper', os.path.join(log_path, 'move_research_data.log'))
+    full_log_path = os.path.join(log_path, 'move_research_data.log')
+    logger = setup_logger('wrapper', full_log_path)
 
     ## Read in demuxdir-runlist.txt
     runlist = config['previous_runs_file_path']
@@ -49,8 +53,12 @@ def wrapper(config_path):
 
             ## Send e-mail if problems with runs
             if len(error_runs) > 0:
-                pass
-               # print(error_runs)
+                recipient = config['email']['recipient']
+                sender = config['email']['sender']
+                subject = config['email']['subject']
+                body = gen_email_body(error_runs, full_log_path)
+
+                send_email(recipient, sender, subject, body)
 
 if __name__ == '__main__':
     wrapper()

--- a/move_researchdata/wrapper.py
+++ b/move_researchdata/wrapper.py
@@ -9,8 +9,10 @@ import sys
 sys.path.append("..")
 from CGG.tools.emailer import send_email
 
+wrapper_path = os.path.abspath(os.path.dirname(__file__))
+
 @click.command()
-@click.option('--config-path', default='configs/wrapper_config.yaml',
+@click.option('--config-path', default=os.path.join(wrapper_path, 'configs/wrapper_config.yaml'),
               type=click.Path(exists=True), help='Path to wrapper config file')
 def wrapper(config_path):
     ## Sanity check. Only run as root
@@ -27,7 +29,7 @@ def wrapper(config_path):
     logger = setup_logger('wrapper', full_log_path)
 
     ## Read in demuxdir-runlist.txt
-    runlist = config['previous_runs_file_path']
+    runlist = os.path.join(wrapper_path, config['previous_runs_file_path'])
     with open(runlist, 'r') as prev:
         previous_runs = [line.rstrip() for line in prev]
 

--- a/move_researchdata/wrapper.py
+++ b/move_researchdata/wrapper.py
@@ -22,7 +22,7 @@ def wrapper(config_path):
 
     ## Initialise logging
     log_path = config['logpath']
-    logger = setup_logger('wrapper', os.path.join(log_path, 'wopr_wrapper.log'))
+    logger = setup_logger('wrapper', os.path.join(log_path, 'move_research_data.log'))
 
     ## Read in demuxdir-runlist.txt
     runlist = config['previous_runs_file_path']

--- a/move_researchdata/wrapper.py
+++ b/move_researchdata/wrapper.py
@@ -4,6 +4,7 @@ import os
 import sys
 import click
 import yaml
+import subprocess
 from tools.helpers import setup_logger, look_for_runs
 
 @click.command()
@@ -41,6 +42,14 @@ def wrapper(config_path):
                 runs_to_process.append(run)
 
     ## Move all research data
+    if len(runs_to_process) > 0:
+        logger.info(f"Found {len(runs_to_process)} run(s) to process")
+    else:
+        sys.exit()
+
+    for run in runs_to_process:
+        cmd_list = ['python','move_researchdata.py', '-d', run]
+        subprocess.run(cmd_list)
 
     ## Add processed demultiplexdir to demuxdir-runlist.txt
 

--- a/move_researchdata/wrapper.py
+++ b/move_researchdata/wrapper.py
@@ -6,12 +6,12 @@ import yaml
 from tools.helpers import setup_logger, look_for_runs, gen_email_body
 from move_researchdata import move_data
 import sys
-sys.path.append("..") # Adds higher directory to python modules path.
+sys.path.append("..")
 from CGG.tools.emailer import send_email
 
 @click.command()
 @click.option('--config-path', default='configs/wrapper_config.yaml',
-              help='Path to wrapper config file')
+              type=click.Path(exists=True), help='Path to wrapper config file')
 def wrapper(config_path):
     ## Sanity check. Only run as root
     if not os.geteuid() == 0:

--- a/move_researchdata/wrapper.py
+++ b/move_researchdata/wrapper.py
@@ -15,8 +15,7 @@ from CGG.tools.emailer import send_email
 def wrapper(config_path):
     ## Sanity check. Only run as root
     if not os.geteuid() == 0:
-        print("ERROR: You need to run this wrapper as root!")
-        sys.exit()
+        sys.exit("ERROR: You need to run this wrapper as root!")
 
     ## Read in the config file
     with open(config_path, 'r') as conf:

--- a/move_researchdata/wrapper.py
+++ b/move_researchdata/wrapper.py
@@ -1,11 +1,21 @@
 #!/usr/bin/env python
 
+import os
+import click
+import yaml
 from tools.helpers import setup_logger
 
-logger = setup_logger('wrapper', os.path.join(ROOT_LOGGING_PATH, 'wopr_wrapper.log'))
-
-def wrapper():
+@click.command()
+@click.option('--config-path', default='configs/wrapper_config.yaml',
+              help='Path to wrapper config file')
+def wrapper(config_path):
     ## Read in the config file
+    with open(config_path, 'r') as conf:
+        config = yaml.safe_load(conf)
+
+    ## Initialise logging
+    log_path = config['logpath']
+    logger = setup_logger('wrapper', os.path.join(log_path, 'wopr_wrapper.log'))
 
     ## Read in demuxdir-runlist.txt
 

--- a/move_researchdata/wrapper.py
+++ b/move_researchdata/wrapper.py
@@ -12,9 +12,9 @@ from tools.helpers import setup_logger, look_for_runs
               help='Path to wrapper config file')
 def wrapper(config_path):
     ## Sanity check. Only run as root
-    #if not os.geteuid() == 0:
-    #    print("ERROR: You need to run this wrapper as root!")
-    #    sys.exit()
+    if not os.geteuid() == 0:
+        print("ERROR: You need to run this wrapper as root!")
+        sys.exit()
 
     ## Read in the config file
     with open(config_path, 'r') as conf:
@@ -49,7 +49,7 @@ def wrapper(config_path):
 
     for run in runs_to_process:
         cmd_list = ['python','move_researchdata.py', '-d', run]
-        #subprocess.run(cmd_list)
+        subprocess.run(cmd_list)
 
     ## Add processed demultiplexdir to demuxdir-runlist.txt
     with open(runlist, 'a') as prev:

--- a/move_researchdata/wrapper.py
+++ b/move_researchdata/wrapper.py
@@ -16,8 +16,8 @@ wrapper_path = os.path.abspath(os.path.dirname(__file__))
               type=click.Path(exists=True), help='Path to wrapper config file')
 def wrapper(config_path):
     ## Sanity check. Only run as root
-    # if not os.geteuid() == 0:
-    #     sys.exit("ERROR: You need to run this wrapper as root!")
+     if not os.geteuid() == 0:
+     sys.exit("ERROR: You need to run this wrapper as root!")
 
     ## Read in the config file
     with open(config_path, 'r') as conf:

--- a/move_researchdata/wrapper.py
+++ b/move_researchdata/wrapper.py
@@ -49,9 +49,12 @@ def wrapper(config_path):
 
     for run in runs_to_process:
         cmd_list = ['python','move_researchdata.py', '-d', run]
-        subprocess.run(cmd_list)
+        #subprocess.run(cmd_list)
 
     ## Add processed demultiplexdir to demuxdir-runlist.txt
+    with open(runlist, 'a') as prev:
+        for run in runs_to_process:
+            prev.write(os.path.basename(run))
 
 if __name__ == '__main__':
     wrapper()

--- a/move_researchdata/wrapper.py
+++ b/move_researchdata/wrapper.py
@@ -4,7 +4,7 @@ import os
 import sys
 import click
 import yaml
-from tools.helpers import setup_logger
+from tools.helpers import setup_logger, look_for_runs
 
 @click.command()
 @click.option('--config-path', default='configs/wrapper_config.yaml',
@@ -29,10 +29,20 @@ def wrapper(config_path):
         previous_runs = [line.rstrip() for line in prev]
 
     ## Find all non processed demultiplex dirs
+    runs_to_process = []
+    for instrument in config['instrument_demux_paths'].keys():
+        demux_path = config['instrument_demux_paths'][instrument]
+        ## Get all demultiplexed runs
+        runs = look_for_runs(demux_path)
+        for run in runs:
+            if os.path.basename(run) in previous_runs:
+                continue # skip previously processed
+            else:
+                runs_to_process.append(run)
 
     ## Move all research data
 
-    ## Add demultiplexdir to demuxdir-runlist.txt
+    ## Add processed demultiplexdir to demuxdir-runlist.txt
 
 if __name__ == '__main__':
     wrapper()

--- a/move_researchdata/wrapper.py
+++ b/move_researchdata/wrapper.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import os
+import sys
 import click
 import yaml
 from tools.helpers import setup_logger
@@ -9,6 +10,11 @@ from tools.helpers import setup_logger
 @click.option('--config-path', default='configs/wrapper_config.yaml',
               help='Path to wrapper config file')
 def wrapper(config_path):
+    ## Sanity check. Only run as root
+    #if not os.geteuid() == 0:
+    #    print("ERROR: You need to run this wrapper as root!")
+    #    sys.exit()
+
     ## Read in the config file
     with open(config_path, 'r') as conf:
         config = yaml.safe_load(conf)

--- a/move_researchdata/wrapper.py
+++ b/move_researchdata/wrapper.py
@@ -16,8 +16,8 @@ wrapper_path = os.path.abspath(os.path.dirname(__file__))
               type=click.Path(exists=True), help='Path to wrapper config file')
 def wrapper(config_path):
     ## Sanity check. Only run as root
-     if not os.geteuid() == 0:
-     sys.exit("ERROR: You need to run this wrapper as root!")
+    if not os.geteuid() == 0:
+        sys.exit("ERROR: You need to run this wrapper as root!")
 
     ## Read in the config file
     with open(config_path, 'r') as conf:
@@ -52,14 +52,14 @@ def wrapper(config_path):
             except Exception as e:
                 error_runs.append(run)
 
-        ## Send e-mail if problems with runs
-        if len(error_runs) > 0:
-            recipient = config['email']['recipient']
-            sender = config['email']['sender']
-            subject = config['email']['subject']
-            body = gen_email_body(error_runs, full_log_path)
+    ## Send e-mail if problems with runs
+    if len(error_runs) > 0:
+        recipient = config['email']['recipient']
+        sender = config['email']['sender']
+        subject = config['email']['subject']
+        body = gen_email_body(error_runs, full_log_path)
 
-            send_email(recipient, sender, subject, body)
+        send_email(recipient, sender, subject, body)
 
 if __name__ == '__main__':
     wrapper()

--- a/move_researchdata/wrapper.py
+++ b/move_researchdata/wrapper.py
@@ -1,8 +1,19 @@
 #!/usr/bin/env python
 
-import click
+from tools.helpers import setup_logger
 
-def look_for_runs(root_path):
-    found_paths = glob.glob(os.path.join(root_path, '*'))
-    regex = '^[0-9]{6}_A[0-9]{5}_[0-9]{4}_.{10}$'
-    return [path for path in found_paths if re.search(regex, os.path.basename(path))]
+logger = setup_logger('wrapper', os.path.join(ROOT_LOGGING_PATH, 'wopr_wrapper.log'))
+
+def wrapper():
+    ## Read in the config file
+
+    ## Read in demuxdir-runlist.txt
+
+    ## Find all non processed demultiplex dirs
+
+    ## Move all research data
+
+    ## Add demultiplexdir to demuxdir-runlist.txt
+
+if __name__ == '__main__':
+    wrapper()


### PR DESCRIPTION
I figured it would be nice to not have to manually keep adding research samples to sFTP folders every time the lab sequences.

This is a wrapper that invokes the move_resaerchsamples script. This should be possible to set up a cronjob, and that way it takes care of this stuff for us.

Since the move_researchdata needs to be root, this script also requires it. Not sure if that was a super nice solution or not

### To test
Start by copying the demuxdir-runlist.txt which contains all previous runs (what to skip).
$ cp /home/xlinak/projects/general/move_researchdata/demuxdir_runlist.txt .
$ sudo su
$ module load miniconda/4.8.3
$ source activate move_research
(Remove a run from the demuxdir_runlist.txt file)
$ python3 wrapper.py